### PR TITLE
Change to readable date

### DIFF
--- a/nginx/public/officeHours.js
+++ b/nginx/public/officeHours.js
@@ -11,7 +11,9 @@ function displayQueue(queueJSON) {
     const queue = JSON.parse(queueJSON);
     let formattedQueue = "";
     for (const student of queue) {
-        formattedQueue += student['username'] + " has been waiting since " + student['timestamp'] + "<br/>"
+        var date = new Date(student['timestamp'])
+        var time = date.getHours() + ":" + date.getMinutes() + ":" + date.getSeconds() + " (" + (date.getMonth()+1) + "/" + date.getDate() + "/" + date.getFullYear() + ")";
+        formattedQueue += student['username'] + " has been waiting since " + time + "<br/>"
     }
     document.getElementById("queue").innerHTML = formattedQueue;
 }

--- a/src/main/scala/model/OfficeHoursServer.scala
+++ b/src/main/scala/model/OfficeHoursServer.scala
@@ -60,7 +60,7 @@ class DisconnectionListener(server: OfficeHoursServer) extends DisconnectListene
 
 class EnterQueueListener(server: OfficeHoursServer) extends DataListener[String] {
   override def onData(socket: SocketIOClient, username: String, ackRequest: AckRequest): Unit = {
-    server.database.addStudentToQueue(StudentInQueue(username, System.nanoTime()))
+    server.database.addStudentToQueue(StudentInQueue(username, System.currentTimeMillis()))
     server.socketToUsername += (socket -> username)
     server.usernameToSocket += (username -> socket)
     server.server.getBroadcastOperations.sendEvent("queue", server.queueJSON())


### PR DESCRIPTION
Store timestamp in database as a UNIX timestamp (milliseconds), rather than nano time.

Add JavaScript to output timestamp in a human-readable form, in UTC to avoid timezone issues.