### PR TITLE
Dark theme and JUMBOTRON

### DIFF
--- a/nginx/public/index.html
+++ b/nginx/public/index.html
@@ -4,20 +4,29 @@
     <meta charset="UTF-8">
     <title>Office Hours</title>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.2.0/socket.io.js"></script>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
 </head>
-<body>
+<body class="text-center text-light bg-dark">
 
 <br/>
 
-<h3 id="message">Welcome!</h3>
+<h3 id="message" class="display-3">Welcome to office hours!</h3>
+<h4 class="text-success">Now with dark mode for the true programmers!</h4>
 
-<p>Name</p>
-<input type="text" id="name"/>
-<button onclick="enterQueue();">Enter Queue</button>
+<p>Enter your name to join the queue</p>
+<input type="text" id="name" class="form-control-lg"/>
+<br>
+<br>
+<button onclick="enterQueue();" class="btn btn-success btn-lg">Enter Queue</button>
 <br/><br/>
 
-<button onclick="readyToHelp();">TA Ready to Help</button>
+<button onclick="readyToHelp();" class="btn btn-primary">TA Ready to Help</button>
 
+<br>
+<br>
+<button onclick="jumbotronButtonPressed();" class="btn btn-sm btn-danger">Use this screen as a JUMBOTRON!</button>
+
+<br/>
 <br/>
 
 <div id="queue"></div>

--- a/nginx/public/officeHours.js
+++ b/nginx/public/officeHours.js
@@ -1,30 +1,36 @@
 const socket = io.connect("http://localhost:8080", {transports: ['websocket']});
 
+let isJumbotron = false; // Keep track of if this is being used as a jumbotron
+// if it is, don't try to reference elements that don't exist on the jumbotron
+
 socket.on('queue', displayQueue);
 socket.on('message', displayMessage);
-
-let queueLength = 0;
+socket.on('jumbotron', updateJumbotron);
 
 function displayMessage(newMessage) {
-    document.getElementById("message").innerHTML = newMessage;
+    if (!isJumbotron) {
+        document.getElementById("message").innerHTML = newMessage;
+    }
 }
 
 function displayQueue(queueJSON) {
     const queue = JSON.parse(queueJSON);
-    queueLength = queue.length;
-    showJumbotron();
     let formattedQueue = "";
     for (const student of queue) {
         formattedQueue += student['username'] + " has been waiting since " + student['timestamp'] + "<br/>"
     }
-    document.getElementById("queue").innerHTML = formattedQueue;
+    if (!isJumbotron) {
+        document.getElementById("queue").innerHTML = formattedQueue;
+    }
 }
 
 
 function enterQueue() {
-    let name = document.getElementById("name").value;
-    socket.emit("enter_queue", name);
-    document.getElementById("name").value = "";
+    if (!isJumbotron) {
+        let name = document.getElementById("name").value;
+        socket.emit("enter_queue", name);
+        document.getElementById("name").value = "";
+    }
 }
 
 function readyToHelp() {
@@ -33,15 +39,50 @@ function readyToHelp() {
 
 function jumbotronButtonPressed() {
     socket.emit("jumbotron");
+    isJumbotron = true;
     showJumbotron()
 }
 
+function updateJumbotron(queueJSON) {
+    const queue = JSON.parse(queueJSON);
+    let queueLength = queue.length;
+    let top = document.getElementById("jumbotop");
+    let mid = document.getElementById("jumbomiddle");
+    let bot = document.getElementById("jumbobottom");
+
+    if (queueLength == 1) {
+        top.innerHTML = "There is";
+        bot.innerHTML = "student in the queue";
+    } else {
+        top.innerHTML = "There are";
+        bot.innerHTML = "students in the queue";
+    }
+
+    if (queueLength === 0) {
+        mid.innerHTML = "no";
+        mid.style.color = "green";
+    } else if (queueLength <= 2) {
+        mid.innerHTML = queueLength;
+        mid.style.color = "green";
+    } else if (queueLength <= 6) {
+        mid.innerHTML = queueLength;
+        mid.style.color = "yellow";
+    } else if (queueLength <= 10) {
+        mid.innerHTML = queueLength;
+        mid.style.color = "orange";
+    } else {
+        mid.innerHTML = queueLength;
+        mid.style.color = "red";
+    }
+}
+
+// Converts the page into a jumbotron, refresh the page to undo
 function showJumbotron() {
     let body = document.getElementsByTagName("body")[0];
     body.innerHTML = ""; // Clear the page
 
-    body.innerHTML += '<h1 class="display-1">There are</h1>';
-    body.innerHTML += '<h1 class="display-1" style="font-size: 3000%;">' + queueLength + '</h1>';
-    body.innerHTML += '<h1 class="display-1">people in the queue</h1>';
+    body.innerHTML += '<h1 id="jumbotop" class="display-1"></h1>';
+    body.innerHTML += '<h1 id="jumbomiddle" class="display-1" style="font-size: 3000%;"></h1>';
+    body.innerHTML += '<h1 id="jumbobottom" class="display-1"></h1>';
 
 }

--- a/nginx/public/officeHours.js
+++ b/nginx/public/officeHours.js
@@ -3,12 +3,16 @@ const socket = io.connect("http://localhost:8080", {transports: ['websocket']});
 socket.on('queue', displayQueue);
 socket.on('message', displayMessage);
 
+let queueLength = 0;
+
 function displayMessage(newMessage) {
     document.getElementById("message").innerHTML = newMessage;
 }
 
 function displayQueue(queueJSON) {
     const queue = JSON.parse(queueJSON);
+    queueLength = queue.length;
+    showJumbotron();
     let formattedQueue = "";
     for (const student of queue) {
         formattedQueue += student['username'] + " has been waiting since " + student['timestamp'] + "<br/>"
@@ -25,4 +29,19 @@ function enterQueue() {
 
 function readyToHelp() {
     socket.emit("ready_for_student");
+}
+
+function jumbotronButtonPressed() {
+    socket.emit("jumbotron");
+    showJumbotron()
+}
+
+function showJumbotron() {
+    let body = document.getElementsByTagName("body")[0];
+    body.innerHTML = ""; // Clear the page
+
+    body.innerHTML += '<h1 class="display-1">There are</h1>';
+    body.innerHTML += '<h1 class="display-1" style="font-size: 3000%;">' + queueLength + '</h1>';
+    body.innerHTML += '<h1 class="display-1">people in the queue</h1>';
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,13 @@
             <version>1.7.28</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/com.typesafe.akka/akka-actor -->
+        <dependency>
+            <groupId>com.typesafe.akka</groupId>
+            <artifactId>akka-actor_2.12</artifactId>
+            <version>2.5.25</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/scala/model/JumbotronData.scala
+++ b/src/main/scala/model/JumbotronData.scala
@@ -1,0 +1,9 @@
+package model
+
+import com.corundumstudio.socketio.SocketIOClient
+
+object JumbotronData {
+
+  var clients: List[SocketIOClient] = Nil // Keep track of jumbotron clients
+
+}

--- a/src/main/scala/model/OfficeHoursServer.scala
+++ b/src/main/scala/model/OfficeHoursServer.scala
@@ -27,6 +27,7 @@ class OfficeHoursServer() {
   server.addDisconnectListener(new DisconnectionListener(this))
   server.addEventListener("enter_queue", classOf[String], new EnterQueueListener(this))
   server.addEventListener("ready_for_student", classOf[Nothing], new ReadyForStudentListener(this))
+  server.addEventListener("jumbotron", classOf[Nothing], new JumbotronListener(this))
 
   server.start()
 
@@ -44,6 +45,9 @@ object OfficeHoursServer {
   }
 }
 
+class JumbotronListener(server: OfficeHoursServer) extends DataListener[Nothing] {
+  override def onData(client: SocketIOClient, data: Nothing, ackSender: AckRequest): Unit = ???
+}
 
 class DisconnectionListener(server: OfficeHoursServer) extends DisconnectListener {
   override def onDisconnect(socket: SocketIOClient): Unit = {


### PR DESCRIPTION
We programmers love the dark theme for everything, so why should we be blinded while joining the office hours queue? Introducing the new DARK THEME for office hours queue!

![Screenshot_831](https://user-images.githubusercontent.com/32116122/81021231-b093a400-8e38-11ea-967b-91da451b5dc8.png)

Of course I did more than just that, but that was absolutely my first priority. What's that new red button? Well let's click it and see!

![Screenshot_825](https://user-images.githubusercontent.com/32116122/81021305-e46ec980-8e38-11ea-8c01-d1c102d51c5f.png)

Woah! It's a JUMBOTRON! Now students walking through Davis Hall can see how many people are in line before them without needing to pull out their phone! Since there are a bunch of screens in Davis that aren't used for much, why not devote one of them to display _useful_ information?

Even if we can't use those displays, we could have a spare laptop display the information like this!

![Screenshot_826](https://user-images.githubusercontent.com/32116122/81021448-2b5cbf00-8e39-11ea-84ec-fde10b6967e7.png)
(pardon the mediocre Photoshop)

It accounts for grammar and increases the intensity of the color as the queue gets longer. Photo montage time!

![Screenshot_827](https://user-images.githubusercontent.com/32116122/81021532-5ba45d80-8e39-11ea-972a-5bf84f01eb78.png)
![Screenshot_828](https://user-images.githubusercontent.com/32116122/81021537-5e06b780-8e39-11ea-95af-23b9786b0002.png)
![Screenshot_829](https://user-images.githubusercontent.com/32116122/81021540-60691180-8e39-11ea-947f-f867239bebcc.png)
![Screenshot_830](https://user-images.githubusercontent.com/32116122/81021544-6232d500-8e39-11ea-9bde-714fed30cf1a.png)

On the backend, the jumbotron is implemented using an actor system. When a client clicks on the red button, it tells the backend that they want to be updated 10 times per second on how many people are in the queue. This could have been completely handled in the frontend, but I know there was a backend requirement for this project, so it's a bit over-engineered.

To exit jumbotron mode, one can simply refresh the page, and they'll go back to the normal view.

Overall, it's some pretty simple stuff, but I think it looks cool while providing a beneficial feature. The jumbotron could even be updated to display information such as which TAs are currently working, and if no TAs are currently working, it could show a Google Calendar for their schedule. Since it receives a JSON string, it wouldn't be too difficult to expand with more information.