### PR TITLE
Prevented students from entering queue multiple times

### DIFF
--- a/src/main/scala/model/OfficeHoursServer.scala
+++ b/src/main/scala/model/OfficeHoursServer.scala
@@ -60,10 +60,12 @@ class DisconnectionListener(server: OfficeHoursServer) extends DisconnectListene
 
 class EnterQueueListener(server: OfficeHoursServer) extends DataListener[String] {
   override def onData(socket: SocketIOClient, username: String, ackRequest: AckRequest): Unit = {
-    server.database.addStudentToQueue(StudentInQueue(username, System.nanoTime()))
-    server.socketToUsername += (socket -> username)
-    server.usernameToSocket += (username -> socket)
-    server.server.getBroadcastOperations.sendEvent("queue", server.queueJSON())
+    if(!server.usernameToSocket.contains(username)){
+      server.database.addStudentToQueue(StudentInQueue(username, System.nanoTime()))
+      server.socketToUsername += (socket -> username)
+      server.usernameToSocket += (username -> socket)
+      server.server.getBroadcastOperations.sendEvent("queue", server.queueJSON())
+    }
   }
 }
 


### PR DESCRIPTION
I went to the OfficeHoursServer class inside the database package and edited the EnterQueueListener, so that when it receives a username from the student, it will check if the username has already been added to its usernameToSocket map in a previous attempt. If the username is already there, the EnterQueueListener won't do anything. If not, it will add the username to its database and send a message of type "queue" to getBroadcastOperations.