### PR TITLE
Front End Refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,25 @@
+#IntelliJ
+*iml
+.idea_modules/
+.idea
+out/
+
+
+#Build Files
+.attach_pid*
+
+
+#Scala
 *.class
 *.log
-.idea/
+
+#Maven
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties

--- a/nginx/public/index.html
+++ b/nginx/public/index.html
@@ -4,26 +4,31 @@
     <meta charset="UTF-8">
     <title>Office Hours</title>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.2.0/socket.io.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/darkmode-js@1.5.5/lib/darkmode-js.min.js"></script>
+
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans&display=swap" rel="stylesheet"> 
+    <link rel="stylesheet" type="text/css" href="officeHours.css">
+
 </head>
 <body>
 
 <br/>
+    <table id="tbl_wrap"><tbody><tr><td id="td_wrap">
 
-<h3 id="message">Welcome!</h3>
+        <h3 id="message">Welcome To Office Hours!</h3>
 
-<p>Name</p>
-<input type="text" id="name"/>
-<button onclick="enterQueue();">Enter Queue</button>
-<br/><br/>
+        <p>Add Yourself To The Queue</p>
+        <input type="text" placeholder="Student Name" id="name"/>
+        <button onclick="enterQueue();" class="submitBtn">Add to Queue</button>
+        <br/><br/>
+        
+        <button onclick="readyToHelp();" class="submitBtn">You are a TA and is ready to help</button>
+        <br/>
+        <br/>
+        <p> Queue Below: </p>
 
-<button onclick="readyToHelp();">TA Ready to Help</button>
-
-<br/>
-
-<div id="queue"></div>
-
-<script src="officeHours.js"></script>
-
-
+        <div id="queue"> <div class="details"> <p>Good job! No students are currently in queue!</p> </div> </div>
+    </td></tr></tbody></table>
+    <script src="officeHours.js"></script>
 </body>
 </html>

--- a/nginx/public/officeHours.css
+++ b/nginx/public/officeHours.css
@@ -1,0 +1,51 @@
+body
+{
+font-family: 'Noto Sans', sans-serif;
+}
+
+html, body, #tbl_wrap 
+{ 
+    height: 100%; 
+    width: 100%; 
+    padding: 10; 
+    margin: 0; 
+}
+
+#td_wrap { 
+    vertical-align: middle;
+    text-align: center; 
+}
+
+
+
+div.details 
+{
+	/*text-align: justify; */
+	font-family: 'Noto Sans', sans-serif;
+	font-size: 12px;
+	color:#4c4c4c;
+}
+
+.submitBtn {
+	border: 0;
+	background-color:#f7f7f7;
+	border-radius:6px;
+	display:inline-block;
+	cursor:pointer;
+	color:#666666;
+	font-family: 'Noto Sans', sans-serif;
+	font-size:15px;
+	font-weight:bold;
+	padding:6px 12px;
+	text-decoration:none;
+}
+.submitBtn:hover {
+	background-color:#7a7a7a;
+	color:#f0f0f0;
+}
+.submitBtn:active {
+	box-shadow:inset 0px 0px 0px 2px #3584E4;
+	position:relative;
+	left:1px;
+    outline: transparent;
+}

--- a/nginx/public/officeHours.css~
+++ b/nginx/public/officeHours.css~
@@ -45,4 +45,7 @@ div.details
 }
 .submitBtn:active {
 	box-shadow:inset 0px 0px 0px 2px #3584E4;
+	position:relative;
+	left:1px;
+    outline: transparent;
 }

--- a/nginx/public/officeHours.js
+++ b/nginx/public/officeHours.js
@@ -9,7 +9,7 @@ function displayMessage(newMessage) {
 
 function displayQueue(queueJSON) {
     const queue = JSON.parse(queueJSON);
-    let formattedQueue = "";
+    let formattedQueue = "<div class=\"details\"> <p>Good job! No students are currently in queue!</p> </div>"
     for (const student of queue) {
         formattedQueue += student['username'] + " has been waiting since " + student['timestamp'] + "<br/>"
     }
@@ -26,3 +26,20 @@ function enterQueue() {
 function readyToHelp() {
     socket.emit("ready_for_student");
 }
+
+var options = {
+  bottom: '64px',              // default: '32px'
+  right: '32px',              // default: '32px'
+  left: 'unset',                // default: 'unset'
+  time: '0.5s',                // default: '0.3s'
+  mixColor: '#f2f2f2',            // default: '#fff'
+  backgroundColor: '#fff',     // default: '#fff'
+  buttonColorDark: '#100f2c',  // default: '#100f2c'
+  buttonColorLight: '#f2f2f2',    // default: '#fff'
+  saveInCookies: true,         // default: true,
+  label: '🌓',                 // default: ''
+  autoMatchOsTheme: true       // default: true
+}
+
+const darkmode = new Darkmode(options);
+darkmode.showWidget();

--- a/nginx/public/officeHours.js
+++ b/nginx/public/officeHours.js
@@ -9,7 +9,7 @@ function displayMessage(newMessage) {
 
 function displayQueue(queueJSON) {
     const queue = JSON.parse(queueJSON);
-    let formattedQueue = "<div class=\"details\"> <p>Good job! No students are currently in queue!</p> </div>"
+    let formattedQueue = "<div class=\"details\"> <p>Good job! No students are currently in queue!</p> </div>";
     for (const student of queue) {
         formattedQueue += student['username'] + " has been waiting since " + student['timestamp'] + "<br/>"
     }


### PR DESCRIPTION
Added a dark mode that can be toggled. I dont know why a toggle is needed, but I guess some people are sadists. This darkmode is able to pull from your system settings. So if you have darkmode enabled on Windows10 or MacOS it will turn it on for you! Additionally a CSS layer was added on to center and stylize everything to look decent. 

Enjoy a Demo making everything look really small on my large screen:
![CS-Demo](https://user-images.githubusercontent.com/16065962/81518852-5f3e5580-930d-11ea-8822-d035367c08b2.gif)

