### PR TITLE
Prevent students from entering if they are already in the queue

### DIFF
--- a/src/main/scala/model/OfficeHoursServer.scala
+++ b/src/main/scala/model/OfficeHoursServer.scala
@@ -60,10 +60,14 @@ class DisconnectionListener(server: OfficeHoursServer) extends DisconnectListene
 
 class EnterQueueListener(server: OfficeHoursServer) extends DataListener[String] {
   override def onData(socket: SocketIOClient, username: String, ackRequest: AckRequest): Unit = {
-    server.database.addStudentToQueue(StudentInQueue(username, System.nanoTime()))
-    server.socketToUsername += (socket -> username)
-    server.usernameToSocket += (username -> socket)
-    server.server.getBroadcastOperations.sendEvent("queue", server.queueJSON())
+    if(server.socketToUsername.keys.toList.contains(socket)){
+      socket.sendEvent("message", "You are already in the queue, please wait unit TA comes to help you! ")
+    }else{
+      server.database.addStudentToQueue(StudentInQueue(username, System.nanoTime()))
+      server.socketToUsername += (socket -> username)
+      server.usernameToSocket += (username -> socket)
+      server.server.getBroadcastOperations.sendEvent("queue", server.queueJSON())
+    }
   }
 }
 


### PR DESCRIPTION
Now one person can only get in the queue once, even though they use a different name.
——————————————————————————————————————
v87210665 is also my account, I'm sorry I used the wrong account, this is the correct account that uses my UBIT email.