### PR TITLE
Allows Users to enter queue once every some specified time. 

### DIFF
--- a/nginx/public/index.html
+++ b/nginx/public/index.html
@@ -10,6 +10,7 @@
 <br/>
 
 <h3 id="message">Welcome!</h3>
+<h3>Allows students to enter into queue only once per 10 seconds. </h3>
 
 <p>Name</p>
 <input type="text" id="name"/>
@@ -24,6 +25,12 @@
 
 <script src="officeHours.js"></script>
 
+
+<br/><br/><br/><br/><br/><hr>
+<div><b>Temporily banned users:</b></div>
+<div id="bannedList"></div>
+<hr/>
+<div><b>Entering in a new or previous name will update all of banned list. Warning: if your entering in a previous name that's currently on banned list, it will update all names, remove ready to enter users, and RE-ADD BACK  your name. </b></div>
 
 </body>
 </html>

--- a/nginx/public/officeHours.js
+++ b/nginx/public/officeHours.js
@@ -26,3 +26,10 @@ function enterQueue() {
 function readyToHelp() {
     socket.emit("ready_for_student");
 }
+
+
+
+socket.on('bannedList', displayBannedList);
+function displayBannedList(BannedList) {
+    document.getElementById("bannedList").innerHTML = BannedList;
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1,16 +1,17 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0">
     <groupId>edu.buffalo.cse</groupId>
-    <artifactId>office-hours</artifactId>
+    <artifactId>cse116</artifactId>
     <modelVersion>4.0.0</modelVersion>
     <url>http://maven.apache.org</url>
     <version>0.0.1</version>
-
-    <properties>
-        <encoding>UTF-8</encoding>
-        <scala.version>2.12.9</scala.version>
-    </properties>
-
     <dependencies>
+
+        <!-- https://mvnrepository.com/artifact/org.scalatest/scalatest -->
+        <dependency>
+            <groupId>org.scalatest</groupId>
+            <artifactId>scalatest_2.12</artifactId>
+            <version>3.0.5</version>
+        </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.typesafe.play/play-json -->
         <dependency>
@@ -19,12 +20,47 @@
             <version>2.7.1</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/org.scalaj/scalaj-http -->
+        <dependency>
+            <groupId>org.scalaj</groupId>
+            <artifactId>scalaj-http_2.12</artifactId>
+            <version>2.4.1</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.scalafx/scalafx -->
+        <dependency>
+            <groupId>org.scalafx</groupId>
+            <artifactId>scalafx_2.12</artifactId>
+            <version>11-R16</version>
+        </dependency>
+
         <!-- https://mvnrepository.com/artifact/mysql/mysql-connector-java -->
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.16</version>
+            <version>8.0.15</version>
         </dependency>
+
+        <!-- https://mvnrepository.com/artifact/com.typesafe.akka/akka-actor -->
+        <dependency>
+            <groupId>com.typesafe.akka</groupId>
+            <artifactId>akka-actor_2.12</artifactId>
+            <version>2.5.25</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.typesafe.akka</groupId>
+            <artifactId>akka-testkit_2.12</artifactId>
+            <version>2.5.25</version>
+        </dependency>
+
+
+        <dependency>
+            <groupId>io.socket</groupId>
+            <artifactId>socket.io-client</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+
 
         <dependency>
             <groupId>com.corundumstudio.socketio</groupId>
@@ -40,49 +76,4 @@
         </dependency>
 
     </dependencies>
-
-    <build>
-        <plugins>
-            
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.4</version>
-                <configuration>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                    <archive>
-                        <manifest>
-                            <mainClass>model.OfficeHoursServer</mainClass>
-                        </manifest>
-                    </archive>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.scala-tools</groupId>
-                <artifactId>maven-scala-plugin</artifactId>
-                <version>2.15.2</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>compile</goal>
-                            <goal>testCompile</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-        </plugins>
-    </build>
-
 </project>

--- a/src/main/scala/model/newFunctionality.scala
+++ b/src/main/scala/model/newFunctionality.scala
@@ -1,0 +1,66 @@
+package main.scala.model
+
+
+
+//@@@@@@@@@---(project contribution)
+//So this puts a limit on the time passed by for each user.
+object newFunctionality {
+
+  def eligibility (username: String): Boolean = {
+
+    //update and remove ready to join users from banned list whenever a previous user or new user attempts to join.
+    var tempNewList: List[String] = List()
+    for (user <-  records.banned){
+      if ((System.nanoTime() - records.usernameToLastTime(user)) / ((10 * 10 * 10 * 10 * 10 * 10 * 10 * 10 * 10)) < 10) {
+        tempNewList = user::tempNewList
+      }
+    }
+    records.banned = tempNewList
+
+
+
+
+    if (records.previousUsernames.contains(username)) { //if it's the user's second time or more, go thru this, if not, then do else.
+      var timeWentBy: Long = (System.nanoTime() - records.usernameToLastTime(username)) / ((10 * 10 * 10 * 10 * 10 * 10 * 10 * 10 * 10)) //This is just a conversion from nanoSeconds to seconds. So for clarity, we'll have time be in seconds when comparing to our expected time.    //println(System.nanoTime() - server.usernameToLastTime(username))    println(timeWentBy)
+      if (timeWentBy > 10) { //If the time since entering queue previously is less than the time limit, then enter, if not, wait more. To speed up, we'll wait 60 seconds only. But you may make a time limit of 3 hours, or even 24 hours(1 day), or even longer.
+
+        records.usernameToLastTime = records.usernameToLastTime + (username -> System.nanoTime()) //update their new time since they're entering now.
+        records.banned =  username::records.banned
+        true //return true to allow entrance since enough time went by.
+
+      }
+      else {
+        false //don't allow entrance, and don't update time since they didn't enter in queue, and continue based on previous entrance time.
+      }
+    }
+
+
+    else{ //all new usernames joined will be added to this list. It's mainly used when deriving previous time in upper code. Used to check if students are a key in the mapping usernameToLastTime.
+      records.previousUsernames = username::records.previousUsernames
+      records.usernameToLastTime = records.usernameToLastTime + (username -> System.nanoTime()) //also save their timing. & return true to allow entrance to queue.
+
+      records.banned = username::records.banned
+
+      true
+    }
+
+
+
+    //All in all, if students first time in, no time is checked, and they get added to usernames list, and to their time mapping. If when second time in or more (determined if they're in list), then they will be checked by their time. If eligible, they proceed to get helped, and their username remains in username list forever, and update to their new last time in. If not eligible, then the time went by will increase until they can enter.
+  }
+
+
+}
+
+object records {
+  var previousUsernames: List[String] = List()
+  var usernameToLastTime: Map[String, Long] = Map()
+
+
+  var banned: List[String] = List()
+}
+
+//note that to simplify testing, I made an easy API that contains all the functionality of the new feature in within here, so it's independent from the server, and the server and it's event handlers won't be needed in the testing. because it's harder to send messages and test the server form unit testing.
+//This new method will be called by the EnterQueueListener event handler, and the API is to just return true of false, based on entrance ability. The only new thing that isn't tested is the event handler deciding to continue or not based on true or false returned from this methods call. Which is simple.
+//Also note that whenever a user joins, the EnterQueueListener always run. And that implies that this method will always run. And note that it should be having the necessary variables, such as previousUsernames, or usernameToLastTime, within the server itself. But since we're keeping the server out of the testing. And this functionality will be called by the servers EnterQueueListener with passing on any relevant data, then we can store the variables data structures outside of the server. And again, the server doesn't need these since it didn't have them before, and and it's not part of the API, and it's only necessary for us. And besides, since they're here, and are here within the file, then the server may access them if necessary.
+//So you may go ahead and persist these w/ a DB or a file, or do what you want you further.

--- a/src/tests/testingOfficeHoursLimiter.scala
+++ b/src/tests/testingOfficeHoursLimiter.scala
@@ -22,6 +22,7 @@ class testingOfficeHoursLimiter extends FunSuite {
 
     model.records.previousUsernames = List()
     model.records.usernameToLastTime = Map()
+    model.records.banned = List()
     //note that since the object records permanently saves, when going from one test to another. And we depend that the object is fresh new, then we need to clear. Or we can also sleep before transiting, or we can also use new usernames.
     //the records object behavior is not important and has undefined behavior, that we could use lead to. Normally, from the servers side currently, on a single run, the object gets filled with users and never gets cleared, and we may persist it occasionally. And when the server restarts, that'll be the only time it clears.
   }
@@ -37,7 +38,7 @@ class testingOfficeHoursLimiter extends FunSuite {
     assert(!model.newFunctionality.eligibility("Liam"))
     assert(!model.newFunctionality.eligibility("Sophia"))
 
-    Thread.sleep(11000)
+    Thread.sleep(12000)
 
     assert(model.newFunctionality.eligibility("Nofal"))
     assert(model.newFunctionality.eligibility("Liam"))
@@ -45,6 +46,8 @@ class testingOfficeHoursLimiter extends FunSuite {
 
     model.records.previousUsernames = List()
     model.records.usernameToLastTime = Map()
+    model.records.banned = List()
+
   }
 
 
@@ -76,6 +79,8 @@ class testingOfficeHoursLimiter extends FunSuite {
 
     model.records.previousUsernames = List()
     model.records.usernameToLastTime = Map()
+    model.records.banned = List()
+
   }
 
 
@@ -93,7 +98,7 @@ class testingOfficeHoursLimiter extends FunSuite {
     assert(!model.newFunctionality.eligibility("Liam")) //Liam was the one who entered queue, and not others.
     assert(model.newFunctionality.eligibility("Sophia"))
 
-    Thread.sleep(11000)
+    Thread.sleep(12000)
     assert(model.newFunctionality.eligibility("Nofal"))
     assert(model.newFunctionality.eligibility("Liam"))
     assert(model.newFunctionality.eligibility("Sophia"))
@@ -102,6 +107,35 @@ class testingOfficeHoursLimiter extends FunSuite {
 
     model.records.previousUsernames = List()
     model.records.usernameToLastTime = Map()
+    model.records.banned = List()
+
+  }
+
+
+
+
+  test("test banned list") {
+
+    assert(model.newFunctionality.eligibility("Nofal"))
+    assert(model.newFunctionality.eligibility("Liam"))
+
+    assert(model.records.banned.contains("Nofal"))
+    assert(model.records.banned.contains("Liam"))
+
+    Thread.sleep(12000)
+    assert(model.records.banned.contains("Nofal"))
+    assert(model.records.banned.contains("Liam"))
+
+    assert(model.newFunctionality.eligibility("Sophia"))
+
+    assert(model.records.banned.contains("Sophia"))
+    assert(!model.records.banned.contains("Nofal"))
+    assert(!model.records.banned.contains("Liam"))
+
+
+    model.records.previousUsernames = List()
+    model.records.usernameToLastTime = Map()
+    model.records.banned = List()
   }
 
 }

--- a/src/tests/testingOfficeHoursLimiter.scala
+++ b/src/tests/testingOfficeHoursLimiter.scala
@@ -1,0 +1,107 @@
+package tests
+import main.scala.model
+import org.scalatest._
+
+class testingOfficeHoursLimiter extends FunSuite {
+
+  test("test one person") {
+
+    var elegibility: Boolean = model.newFunctionality.eligibility("Nofal")
+    assert(elegibility) //this is like the equivalent of when the server's listener runs, adding the person to the queue.
+
+    assert(!model.newFunctionality.eligibility("Nofal"))
+
+    Thread.sleep(11000) //11 seconds to wait.
+    //Note that it will initiate the count to 10 seconds, (not really count, but only record change in time, and if it's greater than 10). But since code takes some time to run, then we need to test at least after 11 seconds to see.
+    //Note that exact precision down to the billionth of a second is not necessary. All we care about is that it waited around 10 seconds, and not 2 seconds or 3 hours. Besides, the program in real life will have a timing of about several hours, but we want to go faster in here. And the exact seconds won't matter. And a few seconds off aren't noticeable by humans. And also it won't be a coincidence that a student is wanting to join at the exact time he think's he's able to.
+
+    assert(model.newFunctionality.eligibility("Nofal"))
+
+
+
+
+    model.records.previousUsernames = List()
+    model.records.usernameToLastTime = Map()
+    //note that since the object records permanently saves, when going from one test to another. And we depend that the object is fresh new, then we need to clear. Or we can also sleep before transiting, or we can also use new usernames.
+    //the records object behavior is not important and has undefined behavior, that we could use lead to. Normally, from the servers side currently, on a single run, the object gets filled with users and never gets cleared, and we may persist it occasionally. And when the server restarts, that'll be the only time it clears.
+  }
+
+
+  test("test more than one person") {
+
+    assert(model.newFunctionality.eligibility("Nofal"))
+    assert(model.newFunctionality.eligibility("Liam")) //So all of these codes like this just initiates the counting, and returns a true or false.
+    assert(model.newFunctionality.eligibility("Sophia"))
+
+    assert(!model.newFunctionality.eligibility("Nofal"))
+    assert(!model.newFunctionality.eligibility("Liam"))
+    assert(!model.newFunctionality.eligibility("Sophia"))
+
+    Thread.sleep(11000)
+
+    assert(model.newFunctionality.eligibility("Nofal"))
+    assert(model.newFunctionality.eligibility("Liam"))
+    assert(model.newFunctionality.eligibility("Sophia"))
+
+    model.records.previousUsernames = List()
+    model.records.usernameToLastTime = Map()
+  }
+
+
+  test("test more than one person, mixed times") {
+
+    assert(model.newFunctionality.eligibility("Nofal"))
+    Thread.sleep(3000)
+    assert(model.newFunctionality.eligibility("Liam"))
+    Thread.sleep(3000)
+    assert(model.newFunctionality.eligibility("Sophia"))
+
+    assert(!model.newFunctionality.eligibility("Nofal"))
+    assert(!model.newFunctionality.eligibility("Liam"))
+    assert(!model.newFunctionality.eligibility("Sophia"))
+
+
+    Thread.sleep(5000)
+    assert(model.newFunctionality.eligibility("Nofal")) //it's been 10 seconds for Nofle
+    assert(!model.newFunctionality.eligibility("Liam"))
+    assert(!model.newFunctionality.eligibility("Sophia"))
+
+    Thread.sleep(3000)
+    assert(model.newFunctionality.eligibility("Liam")) //good...
+    assert(!model.newFunctionality.eligibility("Sophia"))
+
+    Thread.sleep(3000)
+    assert(model.newFunctionality.eligibility("Sophia")) //good...
+
+
+    model.records.previousUsernames = List()
+    model.records.usernameToLastTime = Map()
+  }
+
+
+  test("test more than one person, with targetting") {
+
+    assert(model.newFunctionality.eligibility("Nofal"))
+    assert(model.newFunctionality.eligibility("Liam"))
+    assert(model.newFunctionality.eligibility("Sophia"))
+    Thread.sleep(11000)
+
+
+    assert(model.newFunctionality.eligibility("Liam"))
+
+    assert(model.newFunctionality.eligibility("Nofal"))
+    assert(!model.newFunctionality.eligibility("Liam")) //Liam was the one who entered queue, and not others.
+    assert(model.newFunctionality.eligibility("Sophia"))
+
+    Thread.sleep(11000)
+    assert(model.newFunctionality.eligibility("Nofal"))
+    assert(model.newFunctionality.eligibility("Liam"))
+    assert(model.newFunctionality.eligibility("Sophia"))
+
+
+
+    model.records.previousUsernames = List()
+    model.records.usernameToLastTime = Map()
+  }
+
+}


### PR DESCRIPTION
Nothing changed within the HTML and JS, besides adding some lines of code to them. And nothing changed within the server, except that I changed the EnterQueueListener. And I have added two new files, called newFunctionality and the tests for it.  

The new Feature is that there will be a limit to students entering into the queue. So if the limit is once every two hours, then when a user enters a queue, he may not enter again until another two hours. 

Possible future updates:
1. Make a mini game, that a user can play while waiting. Such as hangman, or number guesser, etc. 
2. Allow first time users to enter in queue before any other 2nd time user, even though the 2nd time users were in line for hours and a new user enters. So there will be leveled queue's. And the 2nd level queue users can't be helped unless the 1st level queue is empty. And same with 3rd and 4th and so on.
3. Develop an administrator webpage that is distinguished from TA's webpages, that'll be used for only 1 head TA of all TA's. And it will have the ability to proctor all the TA's and students. 
4. Allow limited communication between all students waiting in line. Such as sending/commenting emoji's, etc, in the queue line space.  
5. Have the user being helped and TA audio and video be publicly live to the other students waiting in line incase they have the same question. Which may be enabled or disabled by the TA.  